### PR TITLE
docs: Fix simple typo, childen -> children

### DIFF
--- a/out/async-dom/UnwrappedChildrenOfParent.js
+++ b/out/async-dom/UnwrappedChildrenOfParent.js
@@ -19,7 +19,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
 function _setPrototypeOf(o, p) { _setPrototypeOf = Object.setPrototypeOf || function _setPrototypeOf(o, p) { o.__proto__ = p; return o; }; return _setPrototypeOf(o, p); }
 
 var _require = require('./../cutie/exports'),
-    AsyncObject = _require.AsyncObject; // remove parent without removing childen
+    AsyncObject = _require.AsyncObject; // remove parent without removing children
 
 
 var UnwrappedChildrenOfParent =

--- a/src/async-dom/UnwrappedChildrenOfParent.js
+++ b/src/async-dom/UnwrappedChildrenOfParent.js
@@ -3,7 +3,7 @@
 
 const { AsyncObject } = require('./../cutie/exports')
 
-// remove parent without removing childen
+// remove parent without removing children
 class UnwrappedChildrenOfParent extends AsyncObject {
   constructor (parent) {
     super(parent)


### PR DESCRIPTION
There is a small typo in out/async-dom/UnwrappedChildrenOfParent.js, src/async-dom/UnwrappedChildrenOfParent.js.

Should read `children` rather than `childen`.

